### PR TITLE
Section dividers + Last Updated footer

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -235,3 +235,20 @@ code {
   background: var(--c-white);
   padding: 2rem;
 }
+
+/* Issue #31: Homepage Section Dividers */
+nav,
+#main-contributors,
+#call-for-contribution,
+#contributors {
+  border-top: 1px solid #e5e7eb; /* soft light gray divider */
+  padding-top: 2rem;
+  margin-top: 2rem;
+}
+.container h2 {
+  color: #111827;
+  font-weight: 700;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid #e5e7eb; /* soft gray underline */
+  margin-bottom: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -255,17 +255,14 @@
       </section>
 
       <footer>
-        <p>
-          © 2025 Bob Guo •
-          <a
-            href="https://github.com/COD1995/ml-meta"
-            target="_blank"
-            rel="noopener"
-          >
-            View on GitHub
-          </a>
-        </p>
-      </footer>
+      <p>
+        © 2025 Bob Guo •
+        <a href="https://github.com/COD1995/ml-meta" target="_blank" rel="noopener">
+          View on GitHub
+        </a>
+        • Last updated: <span id="lastUpdated"></span>
+      </p>
+    </footer>
     </div>
 
     <!-- ✧ Script to fetch and display GitHub contributors ----------------------- -->
@@ -310,5 +307,15 @@
             '<p class="error">Unable to load contributor list 😢</p>';
         });
     </script>
+    <script>
+      // Auto-fill last updated date
+      document.getElementById("lastUpdated").textContent = new Date(document.lastModified)
+        .toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "long",
+          day: "numeric"
+        });
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
This PR improves homepage readability and clarity with:

- Soft section dividers between Books, Papers, Contributors  
- "Last updated" timestamp in the footer

Closes #31

### Before: 
<img width="1002" height="874" alt="image" src="https://github.com/user-attachments/assets/1917fc62-25f5-4433-9eaa-968bd7b8c5fe" />
<img width="1079" height="877" alt="image" src="https://github.com/user-attachments/assets/c7cebe21-0dd7-4287-aa62-008c0bc480be" />

### After:
<img width="1006" height="880" alt="image" src="https://github.com/user-attachments/assets/bafb1c30-5153-4bcb-9573-afcd0dee5aff" />
<img width="916" height="578" alt="image" src="https://github.com/user-attachments/assets/f8661465-3393-49a4-b12b-dec0e95c0ce0" />
<img width="986" height="752" alt="image" src="https://github.com/user-attachments/assets/170f4312-93e9-4495-bf5b-e0971d67ef2b" />
