### PR TITLE
Add floating Slack button (bottom-left) for quick community access

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -235,3 +235,54 @@ code {
   background: var(--c-white);
   padding: 2rem;
 }
+
+/* Issue #33: Slack Floating Button */
+#slackButton {
+  position: fixed;
+  bottom: 2rem;
+  left: 2rem;
+  background: #4A154B; /* Slack purple */
+  width: 75px;
+  height: 65px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 1.3rem;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  z-index: 1000;
+  cursor: pointer;
+}
+
+/* Slack Icon inside */
+#slackButton svg {
+  width: 28px;
+  height: 28px;
+  fill: #fff; /* Icon stays white */
+}
+
+/* Tail for the speech bubble */
+#slackButton::after {
+  content: "";
+  position: absolute;
+  bottom: -12px; /* Tail below bubble */
+  left: 18px; /* Slightly towards the left */
+  width: 0;
+  height: 0;
+  border-width: 12px 10px 0 10px; /* Tail size */
+  border-style: solid;
+  border-color: #4A154B transparent transparent transparent; /* Slack purple tail */
+  transition: border-color 0.3s ease;
+}
+
+/* Hover effect for button + tail */
+#slackButton:hover {
+  background: #611f69; /* Slightly lighter Slack purple */
+  transform: scale(1.07);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+#slackButton:hover::after {
+  border-color: #611f69 transparent transparent transparent; /* Tail matches hover color */
+}

--- a/index.html
+++ b/index.html
@@ -310,5 +310,25 @@
             '<p class="error">Unable to load contributor list 😢</p>';
         });
     </script>
+    <!-- Issue #33: Floating Slack Button -->
+    <a 
+      href="https://join.slack.com/t/mlmetacommunity/shared_invite/zt-38mj0hx5v-8GyxvZ7lanC9HbywfUOwJw"
+      id="slackButton"
+      target="_blank"
+      rel="noopener"
+      title="Join Slack Community"
+    >
+      <!-- Slack Logo -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 122.8 122.8" fill="#fff">
+        <path d="M30.3 78.6c0 5-4 9-9 9s-9-4-9-9 4-9 9-9h9v9z"/>
+        <path d="M34.8 78.6c0-5 4-9 9-9s9 4 9 9v22.5c0 5-4 9-9 9s-9-4-9-9V78.6z"/>
+        <path d="M44 30.3c-5 0-9-4-9-9s4-9 9-9 9 4 9 9v9H44z"/>
+        <path d="M44 34.8c5 0 9 4 9 9s-4 9-9 9H21.5c-5 0-9-4-9-9s4-9 9-9H44z"/>
+        <path d="M92.5 44c0-5 4-9 9-9s9 4 9 9-4 9-9 9h-9V44z"/>
+        <path d="M88 44c0 5-4 9-9 9s-9-4-9-9V21.5c0-5 4-9 9-9s9 4 9 9V44z"/>
+        <path d="M78.8 92.5c5 0 9 4 9 9s-4 9-9 9-9-4-9-9v-9h9z"/>
+        <path d="M78.8 88c-5 0-9-4-9-9s4-9 9-9h22.5c5 0 9 4 9 9s-4 9-9 9H78.8z"/>
+      </svg>
+    </a>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a floating Slack button to the homepage for easier community engagement.

- Positioned bottom-left, always visible  
- Opens Slack invite in a new tab  
- Non-intrusive design with hover animation

Closes #33

### Before
- Slack invite was only visible in the call-for-contribution section
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/af1cbcfc-f509-4299-b65e-2b1deeac0d87" />

### After
- **Users can join Slack anytime via a floating shortcut**
- Default
<img width="1538" height="868" alt="image" src="https://github.com/user-attachments/assets/7bd404bd-c56e-4c75-b2d8-ae9716f0e1ef" />

- Hover
<img width="1600" height="876" alt="image" src="https://github.com/user-attachments/assets/1a5ab800-b696-4333-a0f4-bebb785d36e9" />
