### PR TITLE
Add Expand/Collapse All buttons and include improvements from #35

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -295,3 +295,51 @@ code {
   opacity: 1;
   visibility: visible;
 }
+
+
+
+/* Issue #35: Persistent Side Navbar */
+.side-nav {
+  position: fixed;
+  top: 50%;
+  left: 1rem;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+/* Navbar links */
+.side-nav a {
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #333;
+  transition: all 0.2s ease;
+  padding: 0.3rem 0.5rem;
+  border-radius: 6px;
+}
+
+/* Hover effect */
+.side-nav a:hover {
+  background: #4a154b;  /* Slack purple for consistency */
+  color: #fff;
+  transform: translateX(4px);
+}
+
+/* Smooth scroll for the whole page */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Optional: Hide navbar on very small screens */
+@media (max-width: 768px) {
+  .side-nav {
+    display: none;
+  }
+}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -343,3 +343,28 @@ html {
     display: none;
   }
 }
+
+/* Issue #37: Expand All & Collapse All Button Styles */
+
+.expand-collapse-controls {
+  display: flex;
+  justify-content: center; /* Centers horizontally */
+  gap: 0.8rem; /* Space between buttons */
+  margin: 1.5rem auto; /* Adds some breathing room */
+  width: 100%; /* Ensures full width so centering works */
+}
+
+.expand-collapse-controls .btn-toggle {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: #4a154b; /* Slack purple for consistency */
+  color: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.expand-collapse-controls .btn-toggle:hover {
+  background: #611f69;
+}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -237,44 +237,49 @@ code {
 }
 
 /* Refined Floating Slack Button */
+/* Issue #35: Slack Floating Button - with corrected tooltip positioning */
 #slackButton {
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  width: 56px; /* A slightly more standard size */
-  height: 56px;
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #4a154b 0%, #301030 100%);
+  background: linear-gradient(135deg, #4a154b 0%, #611f69 100%);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  z-index: 1001; /* Ensure it's above other elements if necessary */
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  z-index: 1001;
+  cursor: pointer;
 }
 
 #slackButton svg {
-  width: 32px; /* Adjusted for better padding */
+  width: 32px;
   height: 32px;
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, fill 0.3s ease;
 }
 
+/* Hover: lift + icon subtle color change */
 #slackButton:hover {
-  transform: translateY(-5px); /* Subtle lift effect */
-  box-shadow: 0 8px 25px rgba(74, 21, 75, 0.5);
+  transform: translateY(-4px);
+  background: linear-gradient(135deg, #611f69, #814388);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.4);
 }
 
 #slackButton:hover svg {
   transform: scale(1.1);
+  fill: #fffd; /* slightly off-white on hover */
 }
 
-/* Tooltip Styling */
+/* Tooltip - now appears to the LEFT for better visibility */
 #slackButton .tooltip {
   position: absolute;
-  left: 70px; /* Position to the right of the button */
+  right: 70px; /* moves tooltip LEFT since button is on right edge */
   top: 50%;
   transform: translateY(-50%);
-  background-color: #1f2937;
+  background: #1f2937;
   color: #fff;
   padding: 6px 12px;
   border-radius: 6px;
@@ -282,8 +287,8 @@ code {
   white-space: nowrap;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
-  z-index: 1002;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
 }
 
 #slackButton:hover .tooltip {

--- a/index.html
+++ b/index.html
@@ -34,7 +34,12 @@
         </p>
       </header>
 
-      
+      <!-- Issue #37: Expand/Collapse all buttons -->      
+      <div class="expand-collapse-controls">
+        <button id="expandAll" class="btn-toggle">⬇️ Expand All</button>
+        <button id="collapseAll" class="btn-toggle">⬆️ Collapse All</button>
+      </div>
+
 
       <nav>
         <!-- ─────────────── MATH FOUNDATIONS ─────────────── -->
@@ -354,5 +359,16 @@
       </svg>
       <span class="tooltip">Join our Slack!</span>
     </a>
+    <script>
+      // Expand All
+      document.getElementById('expandAll').addEventListener('click', () => {
+        document.querySelectorAll('details').forEach(d => d.open = true);
+      });
+
+      // Collapse All
+      document.getElementById('collapseAll').addEventListener('click', () => {
+        document.querySelectorAll('details').forEach(d => d.open = false);
+      });
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,16 @@
     <link rel="stylesheet" href="assets/css/books.css" />
   </head>
 
-  <body>
+  <body id="top">
+    <!-- Issue #35: Persistent Left Navbar -->
+    <nav class="side-nav">
+      <a href="#top">🏠 Home</a>
+      <a href="#math-foundations">📐 Math Foundations</a>
+      <a href="#books">📚 Books</a>
+      <a href="#papers">📄 Papers</a>
+      <a href="#main-contributors">🌟 Main Contributors</a>
+      <a href="#call-for-contribution">🤝 Join the Community</a>
+    </nav>    
     <div class="container">
       <header>
         <h1>Machine Learning Mastery</h1>
@@ -29,7 +38,7 @@
 
       <nav>
         <!-- ─────────────── MATH FOUNDATIONS ─────────────── -->
-        <h2>🖇️ Mathematical Foundations</h2>
+        <h2 id="math-foundations">🖇️ Mathematical Foundations</h2>
         <ul class="nav-list">
           <!-- Proof + Math Comprehension Papers ------------------------------------------------------- -->
           <li class="nav-section">
@@ -50,7 +59,7 @@
             </details>
           </li>
         </ul>
-        <h2>📚 Books</h2>
+        <h2 id="books">📚 Books</h2>
         <ul class="nav-list">
           <!-- Algorithms -->
           <li class="nav-section">
@@ -119,7 +128,7 @@
         </ul>
 
         <!-- ─────────────── PAPERS ─────────────── -->
-        <h2>📄 Papers</h2>
+        <h2 id="papers">📄 Papers</h2>
         <ul class="nav-list">
           <!-- CV Papers ------------------------------------------------------- -->
           <li class="nav-section">


### PR DESCRIPTION
**_Note: This PR also includes the fixes & improvements from PR #35 (Slack button bug & persistent navbar), so merging this will cover both changes._**

This PR introduces two new buttons under the main title to allow users to expand or collapse all sections with a single click.

- Centered Expand All and Collapse All buttons
- Styled to match site branding (Slack purple)
- Smooth interaction for better UX

Closes Issue #37 

- Before 
<img width="1257" height="851" alt="image" src="https://github.com/user-attachments/assets/48bda015-7317-4911-8c56-2fd9e23304bf" />

- After (Expand All Hover)
<img width="1149" height="874" alt="image" src="https://github.com/user-attachments/assets/1ed44fbb-f913-49b8-be31-8cd7099ba26f" />

- After (Collapse All Hover)
<img width="1153" height="858" alt="image" src="https://github.com/user-attachments/assets/b7dd57db-3b36-40cc-9271-fadbb2cfdbb6" />
