### PR TITLE
Add Book Directory for Pattern Classification

### DIFF
--- a/books/pattern-classification/index.html
+++ b/books/pattern-classification/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pattern Classification – Book Home</title>
+
+    <link rel="stylesheet" href="../../assets/css/base.css" />
+    <link rel="stylesheet" href="../../assets/css/book-page.css" />
+  </head>
+
+  <body>
+    <main class="content book-home-content">
+      <a href="../../index.html" class="back-link">← Back to Home Page</a>
+
+      <h1>Pattern Classification&nbsp;&mdash;&nbsp;Table&nbsp;of&nbsp;Contents</h1>
+      <p class="tagline">
+        Based on <em>Pattern Classification</em> by Duda et al. Select a chapter below to jump straight to the material.
+      </p>
+
+      <div class="toc-grid">
+        <!-- Chapter 1 -->
+        <details class="toc-card">
+          <summary><strong>Chapter 1: Introduction</strong></summary>
+          <ul class="toc-list">
+            <li>
+              <a href="chapters/01-introduction.html#overview">Introduction to Pattern Classification</a>
+            </li>
+          </ul>
+        </details>
+
+        <!-- Chapter 2 (Coming Soon) -->
+        <details class="toc-card">
+          <summary><strong>Chapter 2: Bayes Decision Theory</strong></summary>
+          <div style="padding: 0.8rem; color: gray; font-style: italic;">
+            🚧 Coming Soon – This chapter is planned but not yet available.
+          </div>
+        </details>
+      </div>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,10 @@
             <details open>
               <summary>Pattern Classification (Duda et al.)</summary>
               <ul class="chapter-list">
+                <!-- Issue #44: Book Directory for Pattern Classification -->
+                <li>
+                  <a href="books/pattern-classification/index.html">📚 Book Directory</a>
+                </li>
                 <li>
                   <a
                     href="books/pattern-classification/chapters/01-introduction.html"


### PR DESCRIPTION
Added a new Book Directory page for *Pattern Classification* by Duda, Hart, and Stork.

Closes Issue #44 

## Changes
- Added to `books/pattern-classification/index.html` with a clean Table of Contents
- Linked the Book Directory from the homepage under the Pattern Classification section

## Why
This improves navigation and keeps consistency with the Algorithms book section. 

## Screenshots
- Before: 
<img width="1127" height="511" alt="image" src="https://github.com/user-attachments/assets/5415f9b8-90c9-49b8-8a9a-7c0e3125877f" />

- After:
<img width="1166" height="541" alt="image" src="https://github.com/user-attachments/assets/bd3e30f9-9a79-41d0-a398-70c64864b78e" />
<img width="1522" height="517" alt="image" src="https://github.com/user-attachments/assets/3f393358-2d83-4f73-8f6d-47406ede9a0d" />
<img width="1696" height="866" alt="image" src="https://github.com/user-attachments/assets/d1ed55d7-0dfe-438d-bcd6-cb1f56bf1661" />